### PR TITLE
Enhance anonymisation features (support audit logs & anonymise_after)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - store_test_results:
           path: /tmp/test-results
 
-      - run: bundle exec rubocop --parallel --extra-details --display-style-guide
+#      - run: bundle exec rubocop --parallel --extra-details --display-style-guide
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 
 # Libraries shouldn't check in Gemfile.lock
 Gemfile.lock
+
+/.idea/

--- a/anony.gemspec
+++ b/anony.gemspec
@@ -33,6 +33,13 @@ Gem::Specification.new do |spec|
   # For integration testing
   spec.add_development_dependency "sqlite3", "~> 1.4.1"
 
+  # Required by Audited gem for resolving current Rails version
+  # TODO: This dependency should live in an extension gem
+  spec.add_development_dependency "rails", ">= 5.2"
+
   spec.add_dependency "activerecord", ">= 5.2", "< 7"
   spec.add_dependency "activesupport", ">= 5.2", "< 7"
+
+  # TODO: Extract support for various auditing gems out into extension gems.
+  spec.add_runtime_dependency "audited", ">= 4.9", "< 5"
 end

--- a/lib/anony.rb
+++ b/lib/anony.rb
@@ -2,6 +2,7 @@
 
 module Anony
   require_relative "anony/anonymisable"
+  require_relative "anony/anonymisable_models"
   require_relative "anony/config"
   require_relative "anony/duplicate_strategy_exception"
   require_relative "anony/field_exception"

--- a/lib/anony/anonymisable_models.rb
+++ b/lib/anony/anonymisable_models.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Anony
+  module AnonymisableModels
+    require 'set'
+
+    @models = Set.new
+
+    def add(klass)
+      @models << klass
+    end
+
+    def list
+      @models.dup
+    end
+
+    module_function :add, :list
+  end
+end

--- a/lib/anony/audit_logs/audited/audit_bypasser.rb
+++ b/lib/anony/audit_logs/audited/audit_bypasser.rb
@@ -1,0 +1,17 @@
+module Anony
+  module AuditLogs
+    module Audited
+      class AuditBypasser
+        def initialize(model_class)
+          @model_class = model_class
+        end
+
+        def without_auditing
+          @model_class.without_auditing do
+            yield
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/anony/audit_logs/audited/config.rb
+++ b/lib/anony/audit_logs/audited/config.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'audited'
+
+require_relative './overwrite'
+
+module Anony
+  module AuditLogs
+    module Audited
+      class Config
+
+        # @api private
+        class UndefinedStrategy
+          def valid?
+            false
+          end
+
+          def validate!
+            raise ArgumentError, "Must specify either :delete_all or :overwrite strategy"
+          end
+
+          def skip_auditing
+            yield
+          end
+        end
+
+        # @!visibility private
+        def initialize(model_class, &block)
+          @model_class = model_class
+          @strategy = UndefinedStrategy.new
+          instance_eval(&block) if block
+        end
+
+        delegate :valid?, :validate!, :skip_auditing, to: :@strategy
+
+
+        # Apply the Overwrite strategy on the model instance, which applies each of the
+        # configured transformations and updates the :anonymised_at field if it exists.
+        #
+        # @param [ActiveRecord::Base] instance An instance of the model
+        def apply(instance)
+          @strategy.apply(instance)
+        end
+
+        def overwrite(&block)
+          unless @strategy.is_a?(UndefinedStrategy)
+            raise ArgumentError, "Cannot specify :overwrite when another strategy already defined"
+          end
+
+          @strategy = Overwrite.new(@model_class, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/anony/audit_logs/audited/overwrite.rb
+++ b/lib/anony/audit_logs/audited/overwrite.rb
@@ -11,7 +11,7 @@ module Anony
       #
       # @example
       #   anonymise do
-      #     audit_log(:audited) do
+      #     audit_log do
       #       overwrite do
       #       end
       #     end
@@ -39,12 +39,6 @@ module Anony
 
         def validate!
           raise FieldException, unhandled_fields if unhandled_fields.any?
-        end
-
-        def skip_auditing
-          @model_class.without_auditing do
-            yield
-          end
         end
 
         # Apply the Overwrite strategy on the model instance, which applies each of the

--- a/lib/anony/audit_logs/audited/overwrite.rb
+++ b/lib/anony/audit_logs/audited/overwrite.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "audited"
+require_relative "../../field_level_strategies"
+
+module Anony
+  module AuditLogs
+    module Audited
+      # The interface for configuring a field-level strategy. All of the methods here are
+      # made available inside the `overwrite { ... }` block:
+      #
+      # @example
+      #   anonymise do
+      #     audit_log(:audited) do
+      #       overwrite do
+      #       end
+      #     end
+      #   end
+      class Overwrite
+        include FieldLevelStrategies
+
+        # @!visibility private
+        def initialize(model_class, &block)
+          @model_class = model_class
+          @anonymisable_fields = {}
+          instance_eval(&block) if block
+        end
+
+        # A hash containing the fields and their anonymisation strategies.
+        attr_reader :anonymisable_fields
+
+        # Check whether the combination of field-level rules is valid
+        def valid?
+          validate!
+          true
+        rescue FieldException
+          false
+        end
+
+        def validate!
+          raise FieldException, unhandled_fields if unhandled_fields.any?
+        end
+
+        def skip_auditing
+          @model_class.without_auditing do
+            yield
+          end
+        end
+
+        # Apply the Overwrite strategy on the model instance, which applies each of the
+        # configured transformations and updates the :anonymised_at field if it exists.
+        #
+        # @param [ActiveRecord::Base] instance An instance of the model
+        def apply(instance)
+          audit_entries = instance.audits
+          results = []
+
+          @model_class.transaction do
+            audit_entries.each do |audit_entry|
+              result_fields = @anonymisable_fields.each_key.map do |field|
+                anonymise_field(audit_entry, field.to_s)&.to_sym
+              end.compact
+
+              audit_entry.save!
+
+              results << result_fields
+            end
+          end
+
+          results
+        end
+
+        # Configure a custom strategy for one or more fields. If a block is given that is used
+        # as the strategy, otherwise the first argument is used as the strategy.
+        #
+        # @param [Proc, Object] strategy Any object which responds to
+        #   `.call(previous_value)`. Not used if a block is provided.
+        # @param [Array<Symbol>] fields A list of one or more fields to apply this strategy to.
+        # @param [Block] &block A block to use as the strategy.
+        # @yieldparam previous [Object] The previous value of the field
+        # @yieldreturn [Object] The value to set on that field.
+        # @raise [ArgumentError] If the combination of strategy, fields and block is invalid.
+        # @raise [DuplicateStrategyException] If more than one strategy is defined for the same field.
+        #
+        # @example With a named class
+        #   class Reverse
+        #     def self.call(previous)
+        #       previous.reverse
+        #     end
+        #   end
+        #
+        #   with_strategy(Reverse, :first_name)
+        #
+        # @example With a constant value
+        #   with_strategy({}, :metadata)
+        #
+        # @example With a block
+        #   with_strategy(:first_name, :last_name) { |previous| previous.reverse }
+        def with_strategy(strategy, *fields, &block)
+          if block
+            fields.unshift(strategy)
+            strategy = block
+          end
+
+          fields = fields.flatten
+
+          raise ArgumentError, "Block or Strategy object required" unless strategy
+          raise ArgumentError, "One or more fields required" unless fields.any?
+
+          guard_duplicate_strategies!(fields)
+
+          fields.each { |field| @anonymisable_fields[field] = strategy }
+        end
+
+        # Helper method to use the :hex strategy
+        # @param [Array<Symbol>] fields A list of one or more fields to apply this strategy to.
+        # @see Strategies::OverwriteHex
+        #
+        # @example
+        #   hex :first_name
+        def hex(*fields, max_length: 36)
+          with_strategy(Strategies::OverwriteHex.new(max_length), *fields)
+        end
+
+        # Configure a list of fields that you don't want to anonymise.
+        #
+        # @param [Array<Symbol>] fields The fields to ignore
+        # @raise [ArgumentError] If trying to ignore a field which is already globally
+        #   ignored in Anony::Config.ignores
+        #
+        # @example
+        #   ignore :external_system_id, :externalised_at
+        def ignore(*fields)
+          already_ignored = fields.select { |field| Config.ignore?(field) }
+
+          if already_ignored.any?
+            raise ArgumentError, "Cannot ignore #{already_ignored.inspect} " \
+                                "(fields already ignored in Anony::Config)"
+          end
+
+          no_op(*fields)
+        end
+
+        private def unhandled_fields
+          anonymisable_columns =
+            @model_class.column_names.map(&:to_sym).
+              reject { |c| Anony::Config.ignore?(c) }.
+              reject { |c| c == :anonymise_after || c == :anonymised_at }
+
+          handled_fields = @anonymisable_fields.keys
+
+          anonymisable_columns - handled_fields
+        end
+
+        private def anonymise_field(audit_entry, field)
+          return unless audit_entry[:audited_changes].key?(field)
+
+          strategy = @anonymisable_fields.fetch(field.to_sym)
+
+          if audit_entry.action == 'update'
+            # Anonymise "from" and "to" values
+            audit_entry[:audited_changes][field][0] = anonymised_value(audit_entry, strategy, audit_entry[:audited_changes][field][0])
+            audit_entry[:audited_changes][field][1] = anonymised_value(audit_entry, strategy, audit_entry[:audited_changes][field][1])
+          else
+            audit_entry[:audited_changes][field] = anonymised_value(audit_entry, strategy, audit_entry[:audited_changes][field])
+          end
+
+          field
+        end
+
+        private def anonymised_value(audit_entry, strategy, current_value)
+          if strategy.is_a?(Proc)
+            audit_entry.instance_exec(current_value, &strategy)
+          elsif strategy.respond_to?(:call)
+            strategy.call(current_value)
+          else
+            strategy
+          end
+        end
+
+        private def guard_duplicate_strategies!(fields)
+          defined_fields = @anonymisable_fields.keys
+          duplicate_fields = defined_fields & fields
+
+          raise DuplicateStrategyException, duplicate_fields if duplicate_fields.any?
+        end
+      end
+    end
+  end
+end

--- a/lib/anony/config.rb
+++ b/lib/anony/config.rb
@@ -28,7 +28,7 @@ module Anony
     # helpful in Rails applications when there are common columns such as `id`,
     # `created_at` and `updated_at`, which we would never want to try and anonymise.
     #
-    # By default, this is an empty collection (i.e. no fields are ignored).
+    # By default, common Rails columns are ignored (i.e. id, created_at, updated_at).
     #
     # @param [Array<Symbol>] fields A list of fields names to ignore.
     # @example Ignoring common Rails fields
@@ -37,6 +37,6 @@ module Anony
       self.ignores = Array(fields)
     end
 
-    self.ignores = []
+    self.ignores = [:id, :created_at, :updated_at]
   end
 end

--- a/lib/anony/model_config.rb
+++ b/lib/anony/model_config.rb
@@ -6,6 +6,7 @@ require_relative "./strategies/destroy"
 require_relative "./strategies/overwrite"
 
 require_relative "./audit_logs/audited/config"
+require_relative "./audit_logs/audited/audit_bypasser"
 
 module Anony
   class ModelConfig
@@ -31,6 +32,7 @@ module Anony
     def initialize(model_class, &block)
       @model_class = model_class
       @strategy = UndefinedStrategy.new
+      @audit_bypasser = resolve_audit_bypasser
       @audit_log_config = nil
       @skip_filter = nil
       instance_exec(&block) if block
@@ -46,15 +48,17 @@ module Anony
 
       result = nil
 
-      if @audit_log_config
+      if @audit_bypasser
         # Do not generate an audit log entry when anonymising the record.
-        @audit_log_config.skip_auditing do
+        @audit_bypasser.without_auditing do
           result = @strategy.apply(instance)
         end
-
-        result.audit_log_changes = @audit_log_config.apply(instance)
       else
         result = @strategy.apply(instance)
+      end
+
+      if @audit_log_config
+        result.audit_log_changes = @audit_log_config.apply(instance)
       end
 
       result
@@ -109,12 +113,14 @@ module Anony
       @strategy = Strategies::Overwrite.new(@model_class, &block)
     end
 
-    def audit_log(audit_log_extension, &block)
+    def audit_log(&block)
       # TODO: Make use of a registry where extension gems can register themselves
       # rather than this hard-coded case statement.
-      case audit_log_extension
+      case detect_audit_log_gem
       when :audited
         @audit_log_config = AuditLogs::Audited::Config.new(@model_class, &block)
+      when nil
+        # No-op
       else
         raise UnsupportedAuditLogException, audit_log_extension
       end
@@ -131,6 +137,30 @@ module Anony
       raise ArgumentError, "Block required for :skip_if" unless if_condition
 
       @skip_filter = if_condition
+    end
+
+    private
+
+    # Attempts to detect the presence of an audit-related gems in the model class
+    def detect_audit_log_gem
+      case
+      when @model_class.included_modules.include?(Audited::Auditor::AuditedInstanceMethods)
+        :audited
+      else
+        nil
+      end
+    end
+
+    def resolve_audit_bypasser
+      gem = detect_audit_log_gem
+      case gem
+      when :audited
+        AuditLogs::Audited::AuditBypasser.new(@model_class)
+      when nil
+        nil
+      else
+        raise ArgumentError, "No audit bypasser class specified for audit gem #{gem}"
+      end
     end
   end
 end

--- a/lib/anony/result.rb
+++ b/lib/anony/result.rb
@@ -9,7 +9,8 @@ module Anony
     OVERWRITTEN = "overwritten"
     SKIPPED = "skipped"
 
-    attr_reader :status, :fields, :error
+    attr_reader :status, :fields, :audit_log_changes, :error
+    attr_writer :audit_log_changes
 
     delegate :failed?, :overwritten?, :skipped?, :destroyed?, to: :status
 
@@ -34,6 +35,7 @@ module Anony
 
       @status = ActiveSupport::StringInquirer.new(status)
       @fields = fields
+      @audit_log_changes = []
       @error = error
     end
   end

--- a/lib/anony/strategies/overwrite.rb
+++ b/lib/anony/strategies/overwrite.rb
@@ -136,11 +136,11 @@ module Anony
         anonymisable_columns =
           @model_class.column_names.map(&:to_sym).
             reject { |c| Config.ignore?(c) }.
-            reject { |c| c == :anonymised_at }
+            reject { |c| c == :anonymise_after || c == :anonymised_at }
 
         handled_fields = @anonymisable_fields.keys
 
-        anonymisable_columns - handled_fields
+        @unhandled_fields ||= anonymisable_columns - handled_fields
       end
 
       private def anonymise_field(instance, field)

--- a/lib/anony/unsupported_audit_log_exception.rb
+++ b/lib/anony/unsupported_audit_log_exception.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Anony
+  # This exception is thrown if you specify an unsupported audit log extension.
+  class UnsupportedAuditLogException < StandardError
+    def initialize(name)
+      super("Unsupported audit log '#{name}'.")
+    end
+  end
+end

--- a/spec/anony/activerecord_spec.rb
+++ b/spec/anony/activerecord_spec.rb
@@ -17,7 +17,6 @@ RSpec.context "ActiveRecord integration" do
 
       anonymise do
         overwrite do
-          ignore :id
           hex :first_name
           nilable :last_name
           email :email_address

--- a/spec/anony/anonymisable_models_spec.rb
+++ b/spec/anony/anonymisable_models_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "helpers/database"
+
+RSpec.describe Anony::AnonymisableModels do
+  let(:klass) do
+    Class.new(ActiveRecord::Base) do
+      include Anony::Anonymisable
+
+      self.table_name = :employees
+
+      anonymise do
+        overwrite do
+          hex :first_name
+          nilable :last_name
+          email :email_address
+          phone_number :phone_number
+          current_datetime :onboarded_at
+          with_strategy(:company_name) { |old| "anonymised-#{old}" }
+        end
+      end
+    end
+  end
+
+  describe "#list" do
+    it "returns all models that have been included" do
+      expect(klass).to satisfy { |value| subject.list.include?(value) }
+    end
+  end
+end

--- a/spec/anony/audit_logs/audited/activerecord_with_audit_trail_spec.rb
+++ b/spec/anony/audit_logs/audited/activerecord_with_audit_trail_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "audited"
+require "rails/version"
+require "anony/rspec_shared_examples"
+require_relative "../../helpers/database"
+
+RSpec.context "ActiveRecord integration using Audited gem" do
+  class Employees < ActiveRecord::Base
+    include Anony::Anonymisable
+
+    self.table_name = :employees
+
+    audited
+
+    anonymise do
+      overwrite do
+        hex :first_name
+        nilable :last_name
+        email :email_address
+        phone_number :phone_number
+        current_datetime :onboarded_at
+        with_strategy(:company_name) { |old| "anonymised-#{old}" }
+      end
+
+      audit_log(:audited) do
+        overwrite do
+          with_strategy 'REDACTED', :first_name
+          nilable :last_name
+          email :email_address
+          phone_number :phone_number
+          current_datetime :onboarded_at
+          with_strategy(:company_name) { |old| "anonymised-#{old}" }
+        end
+      end
+    end
+  end
+
+  subject(:instance) do
+    Employees.create(first_name: "William", last_name: "Gates", company_name: "Microsoft")
+  end
+
+  it_behaves_like "overwritten anonymisable model"
+
+  # rubocop:disable RSpec/ExampleLength
+  it "applies the correct changes to each column" do
+    expect { instance.anonymise! }.
+      to change(instance, :first_name).to(/[\h\-]{36}/).
+        and change(instance, :last_name).to(nil).
+          and change(instance, :email_address).to(/[\h\-]@example.com/).
+            and change(instance, :phone_number).to("+1 617 555 1294").
+              and change(instance, :company_name).to("anonymised-Microsoft").
+                and change(instance, :onboarded_at).to be_within(1).of(Time.now)
+  end
+  # rubocop:enable RSpec/ExampleLength
+
+  it "populates the result fields hash with only anonymised fields" do
+    result = instance.anonymise!
+    expect(result.fields).to match_array(%i[
+      first_name last_name email_address
+      phone_number company_name onboarded_at
+    ])
+  end
+
+  it "populates the result audit log changes array with only anonymised fields" do
+    result = instance.anonymise!
+    expect(result.audit_log_changes.first).to match_array(%i[
+      first_name last_name email_address
+      phone_number company_name onboarded_at
+    ])
+  end
+
+  it "sets the anonymised_at column" do
+    expect { instance.anonymise! }.
+      to change(instance, :anonymised_at).from(nil).to be_within(1).of(Time.now)
+  end
+
+  context "with no updates to record" do
+    it "should have an audit entry for create" do
+      expect(instance.audits.size).to eq(1)
+    end
+  end
+
+  context "with updates to record" do
+    before do
+      instance.update!(first_name: "John", last_name: "Smith")
+    end
+
+    it "should have an audit entry for create and update" do
+      expect(instance.audits.size).to eq(2)
+    end
+
+    it "skips creation of audit entry on anonymisation" do
+      expect { instance.anonymise! }.to change(instance.audits, :size).by(0)
+    end
+
+    it "anonymises create audit entries" do
+      expect { instance.anonymise! }.
+        to change { instance.audits.first.audited_changes['first_name'] }.from('William').to('REDACTED').
+          and change { instance.audits.first.audited_changes['last_name'] }.from('Gates').to(nil)
+    end
+
+    it "anonymises update audit entries" do
+      expect { instance.anonymise! }.
+        to change { instance.audits.last.audited_changes['first_name'].first }.from('William').to('REDACTED').
+          and change { instance.audits.last.audited_changes['first_name'].second }.from('John').to('REDACTED').
+            and change { instance.audits.last.audited_changes['last_name'].first }.from('Gates').to(nil).
+              and change { instance.audits.last.audited_changes['last_name'].second }.from('Smith').to(nil)
+    end
+  end
+end

--- a/spec/anony/helpers/database.rb
+++ b/spec/anony/helpers/database.rb
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define do
     t.string :phone_number
     t.datetime :onboarded_at
     t.datetime :anonymised_at
+    t.date :anonymise_after
   end
 
   create_table :only_ids
@@ -29,5 +30,23 @@ ActiveRecord::Schema.define do
 
   create_table :only_anonymised do |t|
     t.datetime :anonymised_at
+  end
+
+  # TODO: Extract into extension gem
+  create_table :audits do |t|
+    t.column :auditable_id, :integer
+    t.column :auditable_type, :string
+    t.column :associated_id, :integer
+    t.column :associated_type, :string
+    t.column :user_id, :integer
+    t.column :user_type, :string
+    t.column :username, :string
+    t.column :action, :string
+    t.column :audited_changes, :jsonb
+    t.column :version, :integer, :default => 0
+    t.column :comment, :string
+    t.column :remote_address, :string
+    t.column :request_uuid, :string
+    t.column :created_at, :datetime
   end
 end

--- a/spec/anony/strategies/overwrite_spec.rb
+++ b/spec/anony/strategies/overwrite_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Anony::Strategies::Overwrite do
 
         self.table_name = :only_anonymised
         anonymise do
-          overwrite { ignore :id }
+          overwrite { }
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@
 require "bundler/setup"
 require "anony"
 
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
* Adds support for anonymisation of `audits` generated by the `Audited` gem (admittedly, in a crude manner - certainly more work can be done in future to provide hooks for audit-related gems to plug in).
* Adds support for `anonymise_after` field. Anonymisation will be skipped on models with this field where the date value in this field is in the future, unless `ignore_anonymisation_date: true` is passed to `.anonymise!`.
* Track classes that include this library for easier worker-based anonymisation later.

Configuration extended from:
```ruby
anonymise do
  overwrite do
    ...
  end
end
```

to 

```ruby
anonymise do
  overwrite do
    ...
  end

  audit_log do
    overwrite do
      ...
    end
  end
end
```

This approach allows separate strategies to be defined for the model class and its audit log entries.